### PR TITLE
Add single-container pgstac image (PostGIS + pgstac + STAC FastAPI)

### DIFF
--- a/Containerfile_pgstac_single
+++ b/Containerfile_pgstac_single
@@ -1,0 +1,76 @@
+# Single-container pgstac: PostgreSQL + PostGIS + pgstac schema AND the
+# stac-fastapi-pgstac web API fused into one image.
+#
+# Normally this is deployed as two containers (see podman-compose.yaml):
+#   - ghcr.io/stac-utils/pgstac         -> the PostGIS database with the pgstac schema
+#   - ghcr.io/stac-utils/stac-fastapi-pgstac -> the STAC FastAPI service
+#
+# Here we base on the official pgstac database image (which already ships
+# PostGIS + the pgstac schema and its first-boot init scripts) and add the
+# STAC FastAPI application on top. A small entrypoint starts PostgreSQL in
+# the background, waits for it, then launches the API in the foreground.
+FROM ghcr.io/stac-utils/pgstac:latest
+
+USER root
+
+# Python tooling for the STAC FastAPI app (base image is Debian 11 / Python 3.9)
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends python3-pip python3-venv \
+ && rm -rf /var/lib/apt/lists/*
+
+# stac-fastapi-pgstac 5.0.3 is the latest release that supports Python 3.9,
+# which is what the pgstac base image ships. Pin uvicorn for the ASGI server.
+RUN python3 -m pip install --no-cache-dir -U pip \
+ && python3 -m pip install --no-cache-dir \
+      "stac-fastapi-pgstac==5.0.3" \
+      "uvicorn[standard]"
+
+# Database defaults consumed by the stock postgres entrypoint.
+#
+# PGDATA is deliberately moved off /var/lib/postgresql/data (which the base
+# image declares as a VOLUME, so build-time writes there would be discarded)
+# to /pgdata, an ordinary image path. That lets us initialise the database at
+# build time (below) and ship it inside the image.
+ENV POSTGRES_USER=username \
+    POSTGRES_PASSWORD=password \
+    POSTGRES_DB=postgis \
+    PGUSER=username \
+    PGPASSWORD=password \
+    PGDATABASE=postgis \
+    PGDATA=/pgdata \
+    APP_HOST=0.0.0.0 \
+    APP_PORT=8080
+
+# Initialise the cluster + PostGIS + pgstac schema at BUILD time, then cleanly
+# shut it down. This bakes a ready-to-use database into the image so the
+# container starts in a few seconds at runtime instead of running the ~40s
+# first-boot init every time. On a serverless/ephemeral platform (e.g. Code
+# Engine) that long runtime init races with the platform's health checks and
+# gets killed mid-init, corrupting PGDATA and causing a crash loop; a
+# pre-initialised data dir avoids that entirely.
+# The -c overrides keep the build-time server within modest memory limits
+# regardless of the build host's RAM (the pgstac init script sizes buffers
+# from the host's total memory).
+RUN set -eux; \
+    mkdir -p /pgdata && chown postgres:postgres /pgdata; \
+    bash -c ' \
+      docker-entrypoint.sh postgres \
+        -c shared_buffers=256MB \
+        -c dynamic_shared_memory_type=mmap & \
+      PID=$!; \
+      for i in $(seq 1 120); do \
+        pg_isready -h 127.0.0.1 -p 5432 -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null 2>&1 && break; \
+        kill -0 "$PID" 2>/dev/null || { echo "build-time postgres init failed"; exit 1; }; \
+        sleep 1; \
+      done; \
+      pg_isready -h 127.0.0.1 -p 5432 -U "$POSTGRES_USER" -d "$POSTGRES_DB"; \
+      gosu postgres pg_ctl -D "$PGDATA" -m fast -w stop; \
+    '
+
+COPY pgstac_single_entrypoint.sh /usr/local/bin/pgstac_single_entrypoint.sh
+RUN chmod +x /usr/local/bin/pgstac_single_entrypoint.sh
+
+# 5432 = PostgreSQL, 8080 = STAC FastAPI
+EXPOSE 5432 8080
+
+ENTRYPOINT ["/usr/local/bin/pgstac_single_entrypoint.sh"]

--- a/pgstac_single_entrypoint.sh
+++ b/pgstac_single_entrypoint.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Entrypoint for the fused pgstac + stac-fastapi-pgstac container.
+# Starts PostgreSQL (PostGIS + pgstac) in the background, waits for it to be
+# ready, then runs the STAC FastAPI app in the foreground.
+set -Eeo pipefail
+
+# The STAC FastAPI app reads its DB connection from these env vars. In the
+# single-container setup the database lives on localhost, so default the hosts
+# accordingly while still allowing overrides.
+export POSTGRES_HOST="${POSTGRES_HOST:-127.0.0.1}"
+export POSTGRES_HOST_READER="${POSTGRES_HOST_READER:-127.0.0.1}"
+export POSTGRES_HOST_WRITER="${POSTGRES_HOST_WRITER:-127.0.0.1}"
+export POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+export POSTGRES_PASS="${POSTGRES_PASS:-$POSTGRES_PASSWORD}"
+export POSTGRES_DBNAME="${POSTGRES_DBNAME:-$POSTGRES_DB}"
+
+APP_HOST="${APP_HOST:-0.0.0.0}"
+APP_PORT="${APP_PORT:-8080}"
+
+# Start PostgreSQL via the stock postgres entrypoint. On first boot (empty
+# PGDATA) this also initialises the cluster and runs the pgstac init scripts
+# that load PostGIS and the pgstac schema.
+#
+# The pgstac image's init script sizes shared_buffers/etc. from /proc/meminfo,
+# which in a container reports the *host node's* RAM (e.g. 64 GB) rather than
+# the container's memory limit. That produces settings (e.g. 16 GB
+# shared_buffers) that make postgres fail to start inside a small container.
+# We pass conservative, container-appropriate values on the command line,
+# which override the ALTER SYSTEM values persisted by the init script.
+# dynamic_shared_memory_type=mmap avoids depending on /dev/shm, which is only
+# 64 MB in Code Engine.
+PG_SHARED_BUFFERS="${PG_SHARED_BUFFERS:-256MB}"
+PG_EFFECTIVE_CACHE_SIZE="${PG_EFFECTIVE_CACHE_SIZE:-1GB}"
+PG_MAINTENANCE_WORK_MEM="${PG_MAINTENANCE_WORK_MEM:-128MB}"
+PG_WORK_MEM="${PG_WORK_MEM:-8MB}"
+
+# Process structure note:
+#   PostgreSQL runs in the FOREGROUND as the container's main process, and the
+#   STAC FastAPI app runs in a background waiter that launches once the DB is
+#   ready. This is deliberate: on Code Engine, backgrounding postgres with `&`
+#   and polling caused the postmaster to die before emitting any log line,
+#   while running postgres in the foreground (exec) starts cleanly and reaches
+#   "ready to accept connections". So we keep postgres in the proven-good
+#   foreground path and make the API the background child instead.
+#
+# The background waiter blocks on pg_isready, then exec's uvicorn. Because it
+# is a child of this shell (which we exec into postgres below), it keeps
+# running after the exec and is reparented to the postgres process (same PID).
+echo "[pgstac-single] launching API waiter (starts once PostgreSQL is ready)..."
+(
+  until pg_isready -h 127.0.0.1 -p 5432 -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null 2>&1; do
+    sleep 1
+  done
+  echo "[pgstac-single] PostgreSQL is ready; starting stac-fastapi-pgstac on ${APP_HOST}:${APP_PORT}..."
+  exec uvicorn stac_fastapi.pgstac.app:app --host "$APP_HOST" --port "$APP_PORT"
+) &
+
+# Start PostgreSQL in the foreground as PID-preserving main process. If it
+# exits, the container exits and Code Engine restarts it.
+echo "[pgstac-single] starting PostgreSQL (shared_buffers=${PG_SHARED_BUFFERS})..."
+exec docker-entrypoint.sh postgres \
+  -c shared_buffers="${PG_SHARED_BUFFERS}" \
+  -c effective_cache_size="${PG_EFFECTIVE_CACHE_SIZE}" \
+  -c maintenance_work_mem="${PG_MAINTENANCE_WORK_MEM}" \
+  -c work_mem="${PG_WORK_MEM}" \
+  -c dynamic_shared_memory_type=mmap


### PR DESCRIPTION
## What

Fuses the normally two-container pgstac stack into a **single image** via `Containerfile_pgstac_single`:

- `ghcr.io/stac-utils/pgstac` — PostGIS DB + pgstac schema
- `ghcr.io/stac-utils/stac-fastapi-pgstac` — STAC FastAPI service

## How

- Bases on the official pgstac DB image and pip-installs `stac-fastapi-pgstac==5.0.3` (last release supporting the base image's Python 3.9) + `uvicorn`.
- **DB baked at build time** into a non-volume `PGDATA` (`/pgdata`), so the container starts in seconds instead of running the ~40s first-boot init at runtime.
- **Entrypoint** runs PostgreSQL in the **foreground** (container's main process) and launches uvicorn from a background waiter once `pg_isready` passes. This structure is required on IBM Code Engine — backgrounding postgres there caused the postmaster to die before startup, while foreground reaches "ready to accept connections".

## Testing

- Local (podman) end-to-end at 512M: `/_mgmt/health`, `/`, `/collections` all 200.
- Deployed on IBM Code Engine (single ephemeral instance): live and healthy.

## Caveat

The embedded DB is **ephemeral** — Code Engine has no persistent storage, so loaded collections/items are lost on restart/scale/redeploy. For durable use, point the API at an external managed PostgreSQL instead of the baked-in DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)